### PR TITLE
Fix AllMyToes link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ mime = "image/*"
 exec = "allmytoes"
 ```
 </details>
+
 Make sure you have AllMyToes [installed](https://gitlab.com/allmytoes/allmytoes#installation) and in your PATH.
 
 ## Why would I want this instead of the default image previewer?


### PR DESCRIPTION
You forgot to put a blank line before the link, so it showed up as raw text instead of a link.